### PR TITLE
Disable FIDO2 metadata service

### DIFF
--- a/src/Shark.Fido2.Portal/appsettings.Production.json
+++ b/src/Shark.Fido2.Portal/appsettings.Production.json
@@ -14,7 +14,7 @@
     "AllowNoneAttestation": true,
     "AllowSelfAttestation": true,
     "EnableTrustedExecutionEnvironmentOnly": true,
-    "EnableMetadataService": true,
+    "EnableMetadataService": false,
     "EnableStrictAuthenticatorVerification": false,
     "MetadataServiceConfiguration": {
       "MetadataBlobLocation": "https://mds3.fidoalliance.org/",


### PR DESCRIPTION
Disable FIDO2 metadata service due to constant rate limiting from FIDO2 side